### PR TITLE
4: Add Plausible custom events

### DIFF
--- a/_includes/app/head.html
+++ b/_includes/app/head.html
@@ -3,4 +3,5 @@
 <link defer href="assets/css/style.css" rel="stylesheet">
 
 <!-- Plausible Analytics -->
-<script defer data-domain="2023.prx.org" src="https://plausible.io/js/script.js"></script>
+<script defer data-domain="2023.prx.org" src="https://plausible.io/js/script.outbound-links.js"></script>
+<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,7 +1,6 @@
 (() => {
   document.documentElement.classList.add("js-on");
 
-  let useScrollSelection = false;
   let scrollPath;
   let disableScrollPathLoad = false;
   let menuObserver;
@@ -11,10 +10,19 @@
     .querySelector(centerRectQuery)
     ?.getBoundingClientRect();
 
+  function trackSectionView(sectionId, inputType, navLocation) {
+    if (plausible) {
+      plausible("Section View", { 
+        props: { sectionId, inputType, navLocation },
+        callback: () => {
+          console.log("Section View", { sectionId, inputType, navLocation });
+        }
+      });
+    }
+  }
+
   // Detect user interaction type.
   function detectMouseMove() {
-    useScrollSelection = true;
-
     document.documentElement.classList.add("js-mouse");
 
     window.removeEventListener("mousemove", detectMouseMove);
@@ -144,6 +152,9 @@
 
     const linkId = linkElement.getAttribute("href");
     const id = linkId.match(/#section-([\w-]+)/)[1];
+
+    // Plausible event: Section View
+    trackSectionView(id, "click", "choose");
 
     appendSectionContent(id, linkElement.parentElement);
   }
@@ -280,6 +291,9 @@
     const href = linkElement.getAttribute("href");
     const id = href.match(/^#section-([\w-]+)/)[1];
 
+    // Plausible event: Section View
+    trackSectionView(id, "click", "main");
+
     scrollToSection(id);
   }
 
@@ -293,6 +307,9 @@
     const href = linkElement.getAttribute("href");
     const id = href.match(/^#([\w-]+)/)?.[1];
 
+    // Plausible event: Section View
+    trackSectionView(id, "click", "main");
+
     scrollToAnchorTarget(id);
   }
 
@@ -303,6 +320,9 @@
     const id = hash.match(/#section-([\w-]+)/)?.[1];
 
     if (id) {
+      // Plausible event: Section View
+      trackSectionView(id, "url", "browser");
+
       scrollToSection(id);
     }
   }
@@ -372,6 +392,9 @@
 
           const linkHref = sectionLink.getAttribute("href");
           const id = linkHref.match(/#section-([\w-]+)/)[1];
+
+          // Plausible event: Section View
+          trackSectionView(id, "scroll", "choose");
 
           appendSectionContent(id, menu);
         }


### PR DESCRIPTION
closes #4 

- add outbound link tracking script
- add section view custom event triggers

### To Review
- [x] Start server and go to http://localhost:4000/
- [x] Open dev tools console
- [x] Ensure a warning that event was ignored for localhost (This is Plausible script running)
- [x] Load a section via scrolling
- [x] Ensure a warning that event was ignored for localhost (This is Plausible script running)
- [x] Ensure a "Section View" log is shown with correct prop values
- [x] Load a section via clicking a choose nav card
- [x] Ensure a warning that event was ignored for localhost (This is Plausible script running)
- [x] Ensure a "Section View" log is shown with correct prop values
- [x] Navigate to a section from them main menu
- [x] Ensure a warning that event was ignored for localhost (This is Plausible script running)
- [x] Ensure a "Section View" log is shown with correct prop values

> Once this is deployed and running from `2023.prx.org`, Custom and outbound links events should start showing up in Plausible.