### PR TITLE
30: hide offcanvas on nav link click

### DIFF
--- a/_includes/navbar/navbar-menu.html
+++ b/_includes/navbar/navbar-menu.html
@@ -2,7 +2,7 @@
 
 <ul class="prx-more-links navbar-nav">
   <li class="nav-item">
-    <a class="nav-link prx-organization text-uppercase fst-italic d-flex align-items-center" href="#section-awards" data-bs-dismiss="offcanvas">
+    <a class="nav-link prx-organization text-uppercase fst-italic d-flex align-items-center" href="#section-awards">
       <span class="material-icons me-2" aria-hidden="true">emoji_events</span>
       Awards &amp; Press Highlights
     </a>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -20,11 +20,17 @@ body {
   inset: 0;
   z-index: -1;
   display: grid;
-  grid-template-columns: 50px 1fr;
+  grid-template-columns: 1fr;
+
+  @media (min-width: 768px) {
+    grid-template-columns: 50px 1fr;
+
+    .paths {
+      grid-column: 2;
+    }
+  }
 
   .paths {
-    grid-column: 2;
-
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     grid-column-gap: 1.5rem;

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -18,7 +18,6 @@
 
 .prx-navbar {
   display: grid;
-  position: fixed;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(1, 50px);
   column-gap: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,15 @@
 (() => {
   document.documentElement.classList.add("js-on");
 
+  const offcanvasNavElement = document.getElementById("offcanvasNav");
+  const offcanvasNav = new bootstrap.Offcanvas(offcanvasNavElement);
+
+  document.querySelectorAll("a.nav-link").forEach((link) => {
+    link.addEventListener("click", () => {
+      offcanvasNav.hide();
+    });
+  })
+
   let scrollPath;
   let disableScrollPathLoad = false;
   let menuObserver;
@@ -272,7 +281,7 @@
   function scrollToAnchorTarget(id) {
     if (!id) return;
 
-    const targetElement = document.getElementById(id);
+    const targetElement = document.getElementById(id)?.parentElement;
 
     if (!targetElement) return;
 


### PR DESCRIPTION
Closes #30 

- hide offcanvas on nav link click
- fix bg-paths layout on mobile

### To Review

- [ ] Open menu and click any nav link
- [ ] Ensure offcanvas closes as page scrolls to selected section
- [ ] Repeat on mobile
- [ ] Ensure bg paths line up with choose buttons on mobile