### PR TITLE
More content tweaks

### DIFF
--- a/_includes/navbar/navbar-menu.html
+++ b/_includes/navbar/navbar-menu.html
@@ -22,7 +22,7 @@
   <li class="nav-item">
     <a class="nav-link prx-organization text-uppercase fst-italic d-flex align-items-center" href="#section-financials">
       <span class="material-icons me-2" aria-hidden="true">attach_money</span>  
-      Finances
+      Financials
     </a>
   </li>
   <li class="nav-item">

--- a/_includes/page-types/footer-section.html
+++ b/_includes/page-types/footer-section.html
@@ -37,7 +37,11 @@
     {%- endif -%}
 
     {%- if page.donor-credit -%}
-      <p><em>{{ page.donor-credit }}</em></p>
+    <div class="prx-content"> 
+      <div class="content">
+        <p><em>{{ page.donor-credit }}</em></p>
+      </div>
+    </div>
     {%- endif -%}
 
   </div>

--- a/pages/donor-acknowledgements.html
+++ b/pages/donor-acknowledgements.html
@@ -13,6 +13,7 @@ infographic-number: "15,000"
 infographic: "In fiscal year 2023, more than <b>15,000</b> individuals supported PRX, investing in the future of public media, partnering with us, and seeding the next generation of audio storytellers." 
 donor-quote: "&ldquo;PRX believes in telling the truth and is passionate about getting new stories out there — something that is needed now more than ever.&rdquo;"
 donor-quote-citation:  "Nigel Poor, co-host, co-creator, and co-producer of <a href='https://www.earhustlesq.com/' target='_blank'><em>Ear Hustle</em></a>"
+donor-credit: "Every effort has been made to ensure the accuracy of this report. If errors or omissions have occurred, please accept our apologies and contact Madeline Hansen at 612-330-9246."
 
 ---
 <h4>Champions: $100,000+</h4>
@@ -791,7 +792,9 @@ donor-quote-citation:  "Nigel Poor, co-host, co-creator, and co-producer of <a h
     <dd>Riverside, CA</dd>
     </dl>
   </li>
-</ul>  
+</ul>
+
+<p class="mb-4"><em>*deceased</em></p>
 
 <p>PRX gratefully acknowledges the many institutions and foundations that have generously supported our programs and initiatives over the past year.</p>
 

--- a/pages/templeton.html
+++ b/pages/templeton.html
@@ -19,18 +19,18 @@ infographic: "The open call for The Big Questions Project received more than <b>
 donor-credit: "Generous support for The Big Questions Project comes from the John Templeton Foundation."
 recommendation-name: "If you like <a href='https://www.howgodworks.org/' target='_blank'><em>How God Works</em></a>, you may also enjoy ..."
 recommendation-1: Chutzpod
-recommendation-1-image: https://images.squarespace-cdn.com/content/v1/5a7492c9f43b55cafca95618/1690825953071-NKX6CPRT3LPUANUMJUO1/Chutzpod.2023+logo.jpeg?format=300w
+recommendation-1-image: img/chutzpod.jpg
 recommendation-1-link: https://www.chutzpod.com/
 recommendation-2: Science of Happiness
-recommendation-2-image: https://images.squarespace-cdn.com/content/v1/5a7492c9f43b55cafca95618/1624976376561-ACQ1DFDJWC487F7OZKD2/science_of_happiness.jpg?format=300w
+recommendation-2-image: img/science-happiness.jpg
 recommendation-2-link: https://greatergood.berkeley.edu/podcasts/series/the_science_of_happiness
 recommendation-3: How to Be a Better Human
-recommendation-3-image: /assets/img/betterhuman_podcast_logo.png
+recommendation-3-image: img/betterhuman.jpg
 recommendation-3-link: https://www.ted.com/podcasts/how-to-be-a-better-human
 partner-link: dovetail
-partner-title: Choosing Technology That Supports Public Media
+partner-title: "Choosing Technology That Supports Public Media"
 creator-link: garages
-creator-title: Choosing Our Communities at PRX Podcast Garages
+creator-title: "Choosing Our Communities at PRX Podcast Garages"
 listener-link: the-world
 listener-title: "Choosing the Voices of <em>The World</em>"
 ---


### PR DESCRIPTION
- Reverts a couple of recommendation images to use the hosted version (not squarespace)
- Verbiage tweaks

(holding out for senior leader financial page feedback)