### PR TITLE
HOTFIX: Templeton creator link to training

### DIFF
--- a/pages/templeton.html
+++ b/pages/templeton.html
@@ -29,8 +29,8 @@ recommendation-3-image: img/betterhuman.jpg
 recommendation-3-link: https://www.ted.com/podcasts/how-to-be-a-better-human
 partner-link: dovetail
 partner-title: "Choosing Technology That Supports Public Media"
-creator-link: garages
-creator-title: "Choosing Our Communities at PRX Podcast Garages"
+creator-link: training
+creator-title: "Choosing New Avenues of Content Development"
 listener-link: the-world
 listener-title: "Choosing the Voices of <em>The World</em>"
 ---


### PR DESCRIPTION
- [ ] Ensure menu link to training page functions.
- [ ] Refresh and ensure you can scroll through all 4 creator path pages.