### PR TITLE
pin sha

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           ruby-version: 2.7
       - run: sudo apt-get update && sudo apt-get install -y libvips42 ruby-vips libvips-dev
-      - uses: limjh16/jekyll-action-ts@v2
+      - uses: limjh16/jekyll-action-ts@807a5f09755d777bfd3070e9505d02347844c9b2 #v2
         with:
           enable_cache: true
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 #v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site


### PR DESCRIPTION
Third-party actions are pinned to a full commit SHA, with the human-readable version tag preserved in a trailing comment:

`uses: owner/repo@<40-char-sha>  # vX.Y.Z`